### PR TITLE
Better DRO for TinyG

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -213,7 +213,6 @@ controller.on('TinyG:state', function(data) {
     var wpos = sr.wpos;
     var READY = 1, STOP = 3, END = 4, RUN = 5;
     var canClick = [READY, STOP, END, RUN].indexOf(machineState) >= 0;
-    var units = sr.modal.units;
     var mlabel = 'MPos:';
     var wlabel = 'WPos:';
     switch (sr.modal.units) {

--- a/src/app.js
+++ b/src/app.js
@@ -213,12 +213,40 @@ controller.on('TinyG:state', function(data) {
     var wpos = sr.wpos;
     var READY = 1, STOP = 3, END = 4, RUN = 5;
     var canClick = [READY, STOP, END, RUN].indexOf(machineState) >= 0;
+    var units = sr.modal.units;
+    var mlabel = 'MPos:';
+    var wlabel = 'WPos:';
+    switch (sr.modal.units) {
+    case 'G20':
+        mlabel = 'MPos (in):';
+        wlabel = 'WPos (in):';
+	// TinyG reports machine coordinates in mm regardless of the in/mm mode
+	mpos.x = (mpos.x / 25.4).toFixed(4);
+	mpos.y = (mpos.y / 25.4).toFixed(4);
+	mpos.z = (mpos.z / 25.4).toFixed(4);
+	// TinyG reports work coordinates according to the in/mm mode
+        wpos.x = Number(wpos.x).toFixed(4);
+        wpos.y = Number(wpos.y).toFixed(4);
+        wpos.z = Number(wpos.z).toFixed(4);
+	break;
+    case 'G21':
+        mlabel = 'MPos (mm):';
+        wlabel = 'WPos (mm):';
+	mpos.x = Number(mpos.x).toFixed(3);
+	mpos.y = Number(mpos.y).toFixed(3);
+	mpos.z = Number(mpos.z).toFixed(3);
+        wpos.x = Number(wpos.x).toFixed(3);
+        wpos.y = Number(wpos.y).toFixed(3);
+        wpos.z = Number(wpos.z).toFixed(3);
+    }
 
     $('[data-route="axes"] .control-pad .btn').prop('disabled', !canClick);
     $('[data-route="axes"] [data-name="active-state"]').text(stateText);
+    $('[data-route="axes"] [data-name="mpos-label"]').text(mlabel);
     $('[data-route="axes"] [data-name="mpos-x"]').text(mpos.x);
     $('[data-route="axes"] [data-name="mpos-y"]').text(mpos.y);
     $('[data-route="axes"] [data-name="mpos-z"]').text(mpos.z);
+    $('[data-route="axes"] [data-name="wpos-label"]').text(wlabel);
     $('[data-route="axes"] [data-name="wpos-x"]').text(wpos.x);
     $('[data-route="axes"] [data-name="wpos-y"]').text(wpos.y);
     $('[data-route="axes"] [data-name="wpos-z"]').text(wpos.z);

--- a/src/index.html
+++ b/src/index.html
@@ -137,7 +137,7 @@
                 </div>
             </div>
             <div class="row no-gutter">
-                <div class="col-xs-2">
+                <div class="col-xs-2" data-name="mpos-label">
                     MPos:
                 </div>
                 <div class="col-xs-10">
@@ -153,7 +153,7 @@
                 </div>
             </div>
             <div class="row no-gutter">
-                <div class="col-xs-2">
+                <div class="col-xs-2" data-name="wpos-label">
                     WPos:
                 </div>
                 <div class="col-xs-10">


### PR DESCRIPTION
The DROs for TinyG had two problems:

1. The number of decimal places was not fixed so the display was hard to read when the number shifted from, say, "1" to "1.45"
2. TinyG reports MPos in mm always, but WPos in the current units.  The MPos and WPos DROs were not commensurate in inch mode.  It was very confusing to see them in different units, and changing by different deltas.

This patch fixes that, displaying both MPos and WPos in the current units, with a fixed number of decimal places (4 for in and 3 for mm).  The current units are shown as part of the MPos and WPos labels.

I considered fixing the GRBL DRO units, but that is a much larger problem so I chose to keep this patch directed and small, addressing only the TinyG case.  GRBL is tricky because the position reporting units depend not on the GCode G20/G21 mode, but instead on the $13 setting, so the units used for motion control (e.g. jogging) and the reported units can disagree, leading to great confusion.  This might need to be fixed in cncjs itself, rather than in the pendant.