### PR TITLE
Units in Grbl mode

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -46,6 +46,22 @@ controller.on('serialport:open', function(options) {
     Cookies.set('cnc.port', port);
     Cookies.set('cnc.baudrate', baudrate);
 
+    if (controllerType == 'Grbl') {
+        // Read the settings so we can determine the units for position reports
+        // This will trigger a Grbl:settings callback to set grblReportingUnits
+
+        // This has a problem: The first status report arrives before the
+        // settings report, so interpreting the numbers from the first status
+        // report is ambiguous.  Subsequent status reports are interpreted correctly.
+
+        controller.writeln('$$');
+
+        // Force a new statusreport so we can interpret the numbers correctly.
+        // This fails because, even though a status report request is sent
+        // to Grbl, the app does not send us back a Grbl:state event in response
+        // controller.command('statusreport');
+    }
+
     root.location = '#/axes';
 });
 
@@ -151,12 +167,34 @@ controller.on('serialport:read', function(data) {
     console.log('%cR%c', style, '', data);
 });
 
+// GRBL reports position in units according to the $13 setting,
+// independent of the GCode in/mm parser state.
+// We track the $13 value by watching for the Grbl:settings event and by
+// watching for manual changes via serialport:write.  Upon initial connection,
+// we issue a settings request in serialport:open.
+var grblReportingUnits;  // initially undefined
+
 controller.on('serialport:write', function(data) {
     var style = 'font-weight: bold; line-height: 20px; padding: 2px 4px; border: 1px solid; color: #00529B; background: #BDE5F8';
     console.log('%cW%c', style, '', data);
+
+    // Track manual changes to the Grbl position reporting units setting
+    // We are looking for either $13=0 or $13=1
+    if (cnc.controllerType == 'Grbl') {
+        cmd = data.split('=');
+        if (cmd.length == 2 && cmd[0] == "$13") {
+            grblReportingUnits = cmd[1];
+        }
+    }
 });
 
-controller.on('Grbl:state', function(data) {
+var savedGrblState;
+
+function renderGrblState(data) {
+    if (typeof grblReportingUnits == 'undefined') {
+	savedGrblState = JSON.parse(JSON.stringify(data));
+	return;
+    }
     var status = data.status || {};
     var activeState = status.activeState;
     var mpos = status.mpos;
@@ -164,14 +202,61 @@ controller.on('Grbl:state', function(data) {
     var IDLE = 'Idle', RUN = 'Run';
     var canClick = [IDLE, RUN].indexOf(activeState) >= 0;
 
+    var parserstate = data.parserstate || {};
+
+    // Unit conversion factor - depends on both $13 setting and parser units
+    var factor = 1.0;
+    // Number of postdecimal digits to display; 3 for in, 4 for mm
+    var digits = 4;
+
+    var mlabel = 'MPos:';
+    var wlabel = 'WPos:';
+
+    switch (parserstate.modal.units) {
+    case 'G20':
+        mlabel = 'MPos (in):';
+        wlabel = 'WPos (in):';
+        digits = 4;
+        factor = grblReportingUnits == 0 ? 1/25.4 : 1.0 ;
+        break;
+    case 'G21':
+        mlabel = 'MPos (mm):';
+        wlabel = 'WPos (mm):';
+        digits = 3;
+        factor = grblReportingUnits == 0 ? 1.0 : 25.4;
+        break;
+    }
+
+    mpos.x = (mpos.x * factor).toFixed(digits);
+    mpos.y = (mpos.y * factor).toFixed(digits);
+    mpos.z = (mpos.z * factor).toFixed(digits);
+
+    wpos.x = (wpos.x * factor).toFixed(digits);
+    wpos.y = (wpos.y * factor).toFixed(digits);
+    wpos.z = (wpos.y * factor).toFixed(digits);
+
     $('[data-route="axes"] .control-pad .btn').prop('disabled', !canClick);
     $('[data-route="axes"] [data-name="active-state"]').text(activeState);
+    $('[data-route="axes"] [data-name="mpos-label"]').text(mlabel);
     $('[data-route="axes"] [data-name="mpos-x"]').text(mpos.x);
     $('[data-route="axes"] [data-name="mpos-y"]').text(mpos.y);
     $('[data-route="axes"] [data-name="mpos-z"]').text(mpos.z);
+    $('[data-route="axes"] [data-name="wpos-label"]').text(wlabel);
     $('[data-route="axes"] [data-name="wpos-x"]').text(wpos.x);
     $('[data-route="axes"] [data-name="wpos-y"]').text(wpos.y);
     $('[data-route="axes"] [data-name="wpos-z"]').text(wpos.z);
+}
+
+controller.on('Grbl:state', function(data) {
+    renderGrblState(data);
+});
+
+controller.on('Grbl:settings', function(data) {
+    var settings = data.settings || {};
+    if (settings['$13'] != undefined) {
+        grblReportingUnits = settings['$13'];
+	renderGrblState(savedGrblState);
+    }
 });
 
 controller.on('Smoothie:state', function(data) {
@@ -219,21 +304,21 @@ controller.on('TinyG:state', function(data) {
     case 'G20':
         mlabel = 'MPos (in):';
         wlabel = 'WPos (in):';
-	// TinyG reports machine coordinates in mm regardless of the in/mm mode
-	mpos.x = (mpos.x / 25.4).toFixed(4);
-	mpos.y = (mpos.y / 25.4).toFixed(4);
-	mpos.z = (mpos.z / 25.4).toFixed(4);
-	// TinyG reports work coordinates according to the in/mm mode
+        // TinyG reports machine coordinates in mm regardless of the in/mm mode
+        mpos.x = (mpos.x / 25.4).toFixed(4);
+        mpos.y = (mpos.y / 25.4).toFixed(4);
+        mpos.z = (mpos.z / 25.4).toFixed(4);
+        // TinyG reports work coordinates according to the in/mm mode
         wpos.x = Number(wpos.x).toFixed(4);
         wpos.y = Number(wpos.y).toFixed(4);
         wpos.z = Number(wpos.z).toFixed(4);
-	break;
+        break;
     case 'G21':
         mlabel = 'MPos (mm):';
         wlabel = 'WPos (mm):';
-	mpos.x = Number(mpos.x).toFixed(3);
-	mpos.y = Number(mpos.y).toFixed(3);
-	mpos.z = Number(mpos.z).toFixed(3);
+        mpos.x = Number(mpos.x).toFixed(3);
+        mpos.y = Number(mpos.y).toFixed(3);
+        mpos.z = Number(mpos.z).toFixed(3);
         wpos.x = Number(wpos.x).toFixed(3);
         wpos.y = Number(wpos.y).toFixed(3);
         wpos.z = Number(wpos.z).toFixed(3);


### PR DESCRIPTION
I tried to fix the mm/in problem in Grbl mode and mostly succeeded, after a lot of effort.  The fundamental difficulty is that the units for Grbl's position reports depend on the $13 setting, and cncjs does not maintain up-to-date knowledge of that setting, nor does it synchronize that knowledge with its copy of that position state.

To make things work "mostly right", the pendant asks for the settings on startup and also tracks $13= commands that might be issued via the serial console.  That works except in a rare circumstance.  There is an additional complication that the pendant receives its initial state report prior to the settings response, which required some work to delay the handling of the initial state report.

There are still a couple of problems, which are related to one another:

1. cncjs itself does not handle Grbl units correctly if $13=1 (inch reporting mode).  It seems to assume implicitly that $13=0
2. If you issue $13=1 in the serial console, then immediately restart the pendant, its initial DROs will be wrong because cncjs has a stale copy of the positions in mm units and that is what it tells the pendant.

One possible solution would be to disallow $13=1 when used with cncjs.  That is a potential source of confusion for a user whose machine has that setting.  It would be possible for cncjs to force the $13=0 setting, but that has its own problem in the case where you use both cncjs and other apps to drive the machine.  But maybe that is okay considering how poorly most other Grbl senders handle units.

The best solution, from the standpoint of "just works", would be for the cncjs server app to keep track of $13 and synchronize its position state to the initial value of $13 and later changes.

Please feel free to reject this pull request if you think its too much of a can of worms.  I'm submitting it as an example of the scope of the problem.
