### PR TITLE
Support for custom commands in the 'workspace' page

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -34,6 +34,17 @@ var socket = root.io.connect('', {
     query: 'token=' + token
 });
 
+// Generate buttons for custom commands
+jQuery.get("../api/commands", {token: token, paging: false}, function(data) {
+    data.records.forEach(function(record) {
+        $(".actions").append( function(){
+            return $('<button type="button" class="btn" data-name="' + record.id + '">' + record.title + '</button>').on('click', function() {
+                jQuery.post("../api/commands/run/" + record.id + "?token=" + token);
+            });
+        })
+    });
+});
+
 socket.on('connect', function() {
     $('#loading').remove(); // Remove loading message
     root.cnc.router.init();

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -1,6 +1,9 @@
 [data-route="workspace"] {
   padding: 10px;
 }
+[data-route="workspace"] .actions button {
+  margin-right: 10px;
+}
 [data-route="connection"] {
   padding: 10px;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -38,6 +38,8 @@
             <a href="#/axes" class="list-group-item">Axes</a>
         </ul>
     </div>
+    <div class="form-group actions">
+    </div>
 </div>
 <div class="hidden" data-route="connection">
     <div data-name="msg"></div>


### PR DESCRIPTION
This pull-request adds support for custom CNCjs commands inside the pendant from the 'workspace' page (the section after tapping 'back' from the menu).

Example with 'Shutdown Pi' and 'Test' custom commands rendered as buttons

<img width="320" alt="Screen Shot 2019-04-20 at 9 10 15 PM" src="https://user-images.githubusercontent.com/218876/56465378-ff4ad900-63b0-11e9-8ac5-2c44360cc5a5.png">

Fixes #9 