### PR TITLE
Remove and rewire Marlin-unsupported features

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -367,6 +367,16 @@ controller.on('Marlin:state', function(data) {
     $('[data-route="axes"] [data-name="mpos-z"]').text(pos.z);
 });
 
+controller.on('Marlin:settings', function(data) {
+    // Sleep and unlock are not supported in Marlin
+    $('[data-route="axes"] .sleep').hide();
+    $('[data-route="axes"] .unlock').hide();
+
+    // Cyclestart and feedhold are unimplemented in Marlin so swap with gcode commands instead
+    $('[data-route="axes"] .cyclestart').attr("onclick", "cnc.controller.command('gcode:start')");
+    $('[data-route="axes"] .feedhold').attr("onclick", "cnc.controller.command('gcode:pause')");
+});
+
 controller.listAllPorts();
 
 // Workspace 

--- a/src/index.html
+++ b/src/index.html
@@ -86,10 +86,10 @@
                                     <li>
                                         <a role="menuitem" href="javascript:void(0)" onclick="cnc.controller.command('homing')"><i class="fa fa-home"></i>&nbsp;Homing</a>
                                     </li>
-                                    <li>
+                                    <li class="sleep">
                                         <a role="menuitem" href="javascript:void(0)" onclick="cnc.controller.command('gcode', '$SLP')"><i class="fa fa-bed"></i>&nbsp;Sleep</a>
                                     </li>
-                                    <li>
+                                    <li class="unlock">
                                         <a role="menuitem" href="javascript:void(0)" onclick="cnc.controller.command('unlock')"><i class="fa fa-unlock-alt"></i>&nbsp;Unlock</a>
                                     </li>
                                     <li>
@@ -108,12 +108,12 @@
                     <div class="active-state" data-name="active-state"></div>
                 </div>
                 <div class="col-xs-2">
-                    <button type="button" class="btn btn-default" onclick="cnc.controller.command('cyclestart')">
+                    <button type="button" class="btn btn-default cyclestart" onclick="cnc.controller.command('cyclestart')">
                         <i class="fa fa-play"></i>
                     </button>
                 </div>
                 <div class="col-xs-2">
-                    <button type="button" class="btn btn-default" onclick="cnc.controller.command('feedhold')">
+                    <button type="button" class="btn btn-default feedhold" onclick="cnc.controller.command('feedhold')">
                         <i class="fa fa-pause"></i>
                     </button>
                 </div>


### PR DESCRIPTION
There are several unsupported features in Marlin that made using this pendant a bit confusing at first. This PR removes the unsupported 'Sleep' and 'Unlock' buttons. It also rewires the 'Play' (`cyclestart`) and 'Pause' (`feedhold`) buttons to run `gcode:start` and `gcode:pause` instead since `cyclestart` and `feedhold` also appear to do nothing in Marlin. Here's the relevant code from CNCjs showing those features to be unsupported:

https://github.com/cncjs/cncjs/blob/ee37a22eb39b4375b7726add9c0132407a2cc240/src/app/controllers/Marlin/MarlinController.js#L1113-L1131

```javascript
            'feedhold': () => {
                this.event.trigger('feedhold');
            },
            'cyclestart': () => {
                this.event.trigger('cyclestart');
            },
            'homing': () => {
                this.event.trigger('homing');

                this.writeln('G28.2 X Y Z');
            },
            'sleep': () => {
                this.event.trigger('sleep');

                // Unupported
            },
            'unlock': () => {
                // Unsupported
            },
```