### PR TITLE
800x480 screen support

### DIFF
--- a/src/css/app.css
+++ b/src/css/app.css
@@ -131,6 +131,11 @@
     height: 70px;
   }
 }
+@media ( max-height: 470px ) {
+  [data-route="axes"] .control-pad .bottom-row {
+    display: none;
+  }
+}
 @media (min-width: 992px) {
   [data-route="axes"] {
     font-size: 24px;

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -110,6 +110,27 @@
     height: 40px;
   }
 }
+@media (min-width: 800px) {
+  [data-route="axes"] .active-state {
+    height: 70px;
+  }
+  [data-route="axes"] .dropdown-menu>li>a .fa {
+    width: 40px;
+  }
+  [data-route="axes"] .dropdown-menu {
+    font-size: 30px;
+  }
+  [data-route="connection"] .btn,
+  [data-route="connection"] .form-control,
+  [data-route="workspace"] .btn,
+  [data-route="workspace"] .list-group-item,
+  [data-route="workspace"] .form-control,
+  [data-route="axes"] .btn,
+  [data-route="axes"] .form-control {
+    font-size: 24px;
+    height: 70px;
+  }
+}
 @media (min-width: 992px) {
   [data-route="axes"] {
     font-size: 24px;

--- a/src/index.html
+++ b/src/index.html
@@ -354,6 +354,26 @@
                     </button>
                 </div>
             </div>
+            <div class="row no-gutter bottom-row">
+                <div class="col-xs-4">
+                    <button
+                        type="button"
+                        class="btn btn-default"
+                        title="Disable Motors"
+                        onclick="cnc.controller.command('motor:disable')">
+                        <i class="fa fa-unlock"></i> Disable Motors
+                    </button>
+                </div>
+                <div class="col-xs-4">
+                    <button
+                        type="button"
+                        class="btn btn-default reload"
+                        title="Reload"
+                        onclick="location.reload();">
+                        <i class="fa fa-refresh"></i> Refresh
+                    </button>
+                </div>
+            </div>
         </div>
     </div>
 </div>

--- a/src/index.html
+++ b/src/index.html
@@ -364,7 +364,34 @@
                         <i class="fa fa-unlock"></i> Disable Motors
                     </button>
                 </div>
-                <div class="col-xs-4">
+                <div class="col-xs-2">
+                    <button
+                        type="button"
+                        class="btn btn-default"
+                        title="G92 X0"
+                        onclick="cnc.controller.command('gcode', 'G92 X0')">
+                        G92 X0
+                    </button>
+                </div>
+                <div class="col-xs-2">
+                    <button
+                        type="button"
+                        class="btn btn-default"
+                        title="G92 Y0"
+                        onclick="cnc.controller.command('gcode', 'G92 Y0')">
+                        G92 Y0
+                    </button>
+                </div>
+                <div class="col-xs-2">
+                    <button
+                        type="button"
+                        class="btn btn-default"
+                        title="G92 Z0"
+                        onclick="cnc.controller.command('gcode', 'G92 Z0')">
+                        G92 Z0
+                    </button>
+                </div>
+                <div class="col-xs-2">
                     <button
                         type="button"
                         class="btn btn-default reload"


### PR DESCRIPTION
This PR does two things to better leverage the screen real-estate on 800x480px touch screens (like [this one](https://www.amazon.com/gp/product/B01F3EKJIA)):

1) A new CSS media variant for `min-width: 800px` is added
2) A new row is added to the controls screen when the screen height is > 470px. This row contains a 'Disable Motors' button and a 'Refresh' button for now, but I'm open to other potential buttons in this space.

I'm not great at CSS, so please tell me if there's a better way to think about supporting various screen sizes!

Before:
![image](https://user-images.githubusercontent.com/218876/56465962-088e7280-63be-11e9-9c9b-7331da663928.png)

After:
![localhost_8000_pendant_ (1)](https://user-images.githubusercontent.com/218876/56842442-d52e6680-6849-11e9-9d5f-facdfa656f94.png)