### PR TITLE
G30 is unsupported in Marlin so split the G28 button into 'G28 X Y' and 'G28 Z'

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -375,6 +375,10 @@ controller.on('Marlin:settings', function(data) {
     // Cyclestart and feedhold are unimplemented in Marlin so swap with gcode commands instead
     $('[data-route="axes"] .cyclestart').attr("onclick", "cnc.controller.command('gcode:start')");
     $('[data-route="axes"] .feedhold').attr("onclick", "cnc.controller.command('gcode:pause')");
+
+    // G30 is unsupported in Marlin, so split the G28 button into both G28 X Y and G28 Z buttons
+    $('[data-route="axes"] .g28').attr("onclick", "cnc.controller.command('gcode', 'G28 X Y')").text("G28 X Y");
+    $('[data-route="axes"] .g30').attr("onclick", "cnc.controller.command('gcode', 'G28 Z')").text("G28 Z");
 });
 
 controller.listAllPorts();

--- a/src/index.html
+++ b/src/index.html
@@ -209,7 +209,7 @@
                 <div class="col-xs-2">
                     <button
                         type="button"
-                        class="btn btn-default"
+                        class="btn btn-default g28"
                         title="G28"
                         onclick="cnc.sendMove('G28')"
                     >
@@ -219,7 +219,7 @@
                 <div class="col-xs-2">
                     <button
                         type="button"
-                        class="btn btn-default"
+                        class="btn btn-default g30"
                         onclick="cnc.sendMove('G30')"
                     >
                         G30


### PR DESCRIPTION
I _bet_ most users with Marlin machines have a fairly DIY setup (e.g. MPCNC), and I bet a touch plate is not a permanent fixture in most of those machines.

If my assumptions about Marlin users are correct, then it's much more useful to have separate `G28 X Y` and `G28 Z` buttons. `G30` is not supported in Marlin so that's a perfect place to put the second button.